### PR TITLE
Handling of orders without button description

### DIFF
--- a/coinbase/models.py
+++ b/coinbase/models.py
@@ -21,7 +21,7 @@ class Order(models.Model):
     custom = models.TextField(blank=True)
     button_type = models.CharField(max_length=100)
     button_name = models.CharField(max_length=200)
-    button_description = models.TextField(blank=True)
+    button_description = models.TextField(blank=True, null=True)
     button_id = models.CharField(max_length=32)
     transaction_id = models.CharField(max_length=24)
     transaction_hash = models.CharField(max_length=64)

--- a/coinbase/tests.py
+++ b/coinbase/tests.py
@@ -83,3 +83,4 @@ class OrderTests(TestCase):
 
         order = Order.process(self.notification_data)
         self.assertEquals(order.order_id, self.notification_data["order"]["id"])
+        self.assertIsNone(order.button_description)

--- a/coinbase/tests.py
+++ b/coinbase/tests.py
@@ -75,3 +75,11 @@ class OrderTests(TestCase):
         self.assertEquals(order.order_id, self.notification_data["order"]["id"])
         self.assertEquals(order.satoshi, 100000000)
         self.assertEquals(order.cents, 1253)
+
+    @patch("requests.get")
+    def test_process_handling_order_data_without_description(self, GetMock):
+        self.notification_data["order"]["button"]["description"] = None
+        GetMock.return_value.json.return_value = self.notification_data
+
+        order = Order.process(self.notification_data)
+        self.assertEquals(order.order_id, self.notification_data["order"]["id"])


### PR DESCRIPTION
Handling of orders without button descriptions fails with IntegrityError because the corresponding model field is not nullable.
